### PR TITLE
Change Voltage chart to use suggested min/max

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -2433,14 +2433,14 @@
                             },
                             y: {
                                 min: 0,
-                                max: 30,
+                                suggestedMax: 6,
                                 ticks: {
                                     callback: (label) => `${label}V`,
                                 },
                             },
                             y1: {
-                                min: -500,
-                                max: 500,
+                                suggestedMin: -50,
+                                suggestedMax: 50,
                                 ticks: {
                                     stepSize: 50,
                                     callback: (label) => `${label}mA`,


### PR DESCRIPTION
The Voltage/Current chart often either shows lines with so little variation that you cannot see changes, or the values go off the top/bottom.

This change allows the chart to adapt dynamically to the values being returned.

For me it changes from this, showing little detail on the voltage, and with current cut off:
![image](https://github.com/user-attachments/assets/824deeed-6247-4294-ba3a-2fcd4cb7732e)

to this:
![image](https://github.com/user-attachments/assets/a5561408-f456-4a0d-871e-8e41544d0c5d)

Especially handy when the solar generates over 750mA